### PR TITLE
Updated DecoratorFG and DecoratorHead in JetBrains themes so that they play nicely with SourceGit 2.27+ Dark mode

### DIFF
--- a/themes/JetBrainsDark.json
+++ b/themes/JetBrainsDark.json
@@ -26,6 +26,7 @@
     "DecoratorIcon": "#ffffff",
     "DecoratorBranch": "#3574f0",
     "DecoratorTag": "#57935d",
-    "DecoratorFG": "#ffffff"
+    "DecoratorFG": "#000000",
+    "DecoratorHead": "#f4f1de"
   }
 }

--- a/themes/JetBrainsDark_DiffHighContrast.json
+++ b/themes/JetBrainsDark_DiffHighContrast.json
@@ -26,7 +26,8 @@
     "DecoratorIcon": "#ffffff",
     "DecoratorBranch": "#3574f0",
     "DecoratorTag": "#57935d",
-    "DecoratorFG": "#ffffff"
+    "DecoratorFG": "#000000",
+    "DecoratorHead": "#f4f1de"
   },
   "GraphPenThickness": 2,
   "GraphColors": [


### PR DESCRIPTION
This is my attempt at fixing issue #3.

I altered  both 'JetBrains' themes so that the local branch decorator is readable when using SourceGit 2.27+

Here is a before/after comparison of `JetBrainsDark_DiffHighContrast.json` (a similar change was applied to `JetBrainsDark.json`:

| Before  | After  |
| ------------- | ------------ |
| ![Before](https://github.com/user-attachments/assets/f219ae59-cbb5-4084-b717-c3c48cab0a9f) | ![After](https://github.com/user-attachments/assets/72d3e6e8-7457-48e6-b137-1a8c3b63637b) |
