### PR TITLE
optimize: refine Solarized theme colors

### DIFF
--- a/themes/Solarized_Dark.json
+++ b/themes/Solarized_Dark.json
@@ -6,7 +6,7 @@
     "ToolBar": "#002b36",
     "Popup": "#073642",
     "Contents": "#073642",
-    "HistoryBG": "#073642",
+    "HistoryBG": "#01303c",
     "Badge": "#268bd2",
     "BadgeFG": "#fdf6e3",
     "Conflict": "#5c3928",
@@ -24,7 +24,9 @@
     "Diff.AddedHighlight": "#235444",
     "Diff.DeletedHighlight": "#653636",
     "SystemAccentColor": "#268bd2",
-    "Link": "#268bd2"
+    "Link": "#268bd2",
+    "InlineCode": "#30ffffff",
+    "InlineCodeFG": "#d7ba7d"
   },
   "GraphPenThickness": 2,
   "OpacityForNotMergedCommits": 0.4,

--- a/themes/Solarized_Light.json
+++ b/themes/Solarized_Light.json
@@ -6,7 +6,7 @@
     "ToolBar": "#fdf6e3",
     "Popup": "#fdf6e3",
     "Contents": "#eee8d5",
-    "HistoryBG": "#eee8d5",
+    "HistoryBG": "#faf3e0",
     "Badge": "#268bd2",
     "BadgeFG": "#fdf6e3",
     "Conflict": "#f7d8c4",
@@ -24,7 +24,9 @@
     "Diff.AddedHighlight": "#cbdcab",
     "Diff.DeletedHighlight": "#eeb9a6",
     "SystemAccentColor": "#268bd2",
-    "Link": "#268bd2"
+    "Link": "#268bd2",
+    "InlineCode": "#d1cbba",
+    "InlineCodeFG": "#cf8806"
   },
   "GraphPenThickness": 2,
   "OpacityForNotMergedCommits": 0.4,


### PR DESCRIPTION
## Summary
- give the history view a distinct background in both Solarized themes
- add palette-aligned foreground and background colors for inline code

## Validation
- parsed both theme files with `jq`
- verified color formats and theme numeric ranges
- ran `git diff --check`